### PR TITLE
Update status badge and crate authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "odht"
 version = "0.1.0"
-authors = ["Michael Woerister <michaelwoerister@posteo.de>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 exclude = ["/.github/*"]
 description = "A Rust crate for hash tables that can be mapped from disk into memory without the need for up-front decoding."
+repository = "https://github.com/rust-lang/odht"
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI Status](https://github.com/michaelwoerister/odht/actions/workflows/ci.yml/badge.svg)
+![CI Status](https://github.com/rust-lang/odht/actions/workflows/ci.yml/badge.svg)
 
 # odht
 


### PR DESCRIPTION
The status badge was still pointing to the old URL.