### PR TITLE
Bump crate version to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odht"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 exclude = ["/.github/*"]


### PR DESCRIPTION
Bump crate version so we can use it in https://github.com/rust-lang/rust/pull/82183.

r? @wesleywiser 