### PR TITLE
Guard against integer overflow in Factor::apply() and Factor::apply_inverse()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  # CAUTION: Do not rename this job. GH expects a job with this name to pass
+  #          before it will allow merging a PR.
+  required-checks:
+    needs:
+      - build
+      - test-with-sanitizer
+    steps:
+      - name: mark the job as a success or failure
+        run: exit 0
+        shell: bash
+    name: Required Checks Passed
+    runs-on: ubuntu-latest
+
   build:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,40 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        arch: [x86_64, i686]
+        exclude:
+          # i686 does not exist for macOS
+          - os: macos-latest
+            arch: i686
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      # This is string environment variable which happens to be JSON.
+      # We use the builtin fromJSON() function below to convert it into
+      # a map.
+      target_map: |
+        {
+          "ubuntu-latest": "unknown-linux-gnu",
+          "windows-latest": "pc-windows-msvc",
+          "macos-latest": "apple-darwin"
+        }
 
     steps:
     - uses: actions/checkout@v2
     - name: Update Stable Rust
       run: rustup update stable
+    - name: Install GCC multilib
+      if: ${{ matrix.arch == 'i686' && matrix.os == 'ubuntu-latest' }}
+      run: sudo apt install -y gcc-multilib
+    - name: Add target architecture
+      run: rustup target add ${{ matrix.arch }}-${{ fromJSON(env.target_map)[matrix.os] }}
     - name: Check formatting
       run: cargo fmt -- --check
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --target ${{ matrix.arch }}-${{ fromJSON(env.target_map)[matrix.os] }}
     - name: Run tests (no_simd)
-      run: cargo test --verbose --features=no_simd
+      run: cargo test --verbose --target ${{ matrix.arch }}-${{ fromJSON(env.target_map)[matrix.os] }} --features=no_simd
     - name: Build docs
       run: cargo doc --verbose
 

--- a/src/memory_layout.rs
+++ b/src/memory_layout.rs
@@ -38,7 +38,7 @@ const HEADER_TAG: [u8; 4] = *b"ODHT";
 const HEADER_SIZE: usize = size_of::<Header>();
 
 impl Header {
-    pub fn sanity_check<'a, C: Config>(&self, raw_bytes: &[u8]) -> Result<(), Error> {
+    pub fn sanity_check<C: Config>(&self, raw_bytes: &[u8]) -> Result<(), Error> {
         assert!(align_of::<Header>() == 1);
         assert!(HEADER_SIZE % 8 == 0);
 


### PR DESCRIPTION
On 32-bit system it is actually realistic to work with numbers that can overflow here, i.e. a slot count greater than 2^16 is likely to happen. This PR fixes this overflow problems by always working with u128 which is large enough to perform multiplications of `usize::MAX` on any platform.

The PR also adds testing for i686 to CI.