### PR TITLE
Bump crate version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odht"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 exclude = ["/.github/*"]


### PR DESCRIPTION
Create a new release so we can use the bug fix from https://github.com/rust-lang/odht/pull/14 in the compiler.

r? @wesleywiser 