### PR TITLE
Endianness was incorrectly assumed for GroupWord

### DIFF
--- a/src/swisstable_group_query/no_simd.rs
+++ b/src/swisstable_group_query/no_simd.rs
@@ -29,13 +29,13 @@ impl GroupQuery {
         // has pretty much the same effect as a hash collision, something
         // that we need to deal with in any case anyway.
 
-        let group = GroupWord::from_ne_bytes(*group);
+        let group = GroupWord::from_le_bytes(*group);
         let cmp = group ^ repeat(h2);
         let high_bit_greater_than_128 = (!cmp) & repeat(0x80);
         let high_bit_greater_than_128_or_zero = cmp.wrapping_sub(repeat(0x01));
-        let eq_mask = (high_bit_greater_than_128_or_zero & high_bit_greater_than_128).to_le();
+        let eq_mask = high_bit_greater_than_128_or_zero & high_bit_greater_than_128;
 
-        let empty_mask = (group & repeat(0x80)).to_le();
+        let empty_mask = group & repeat(0x80);
 
         GroupQuery {
             eq_mask,

--- a/src/swisstable_group_query/no_simd.rs
+++ b/src/swisstable_group_query/no_simd.rs
@@ -29,7 +29,7 @@ impl GroupQuery {
         // has pretty much the same effect as a hash collision, something
         // that we need to deal with in any case anyway.
 
-        let group = GroupWord::from_le_bytes(*group);
+        let group = GroupWord::from_ne_bytes(*group);
         let cmp = group ^ repeat(h2);
         let high_bit_greater_than_128 = (!cmp) & repeat(0x80);
         let high_bit_greater_than_128_or_zero = cmp.wrapping_sub(repeat(0x01));


### PR DESCRIPTION
This assumption caused incorrect slots to chosen which would lead to it being unusable.

Likely also the cause for https://github.com/rust-lang/rust/issues/90123, though I have not tested if it resolves it.

Tested on Linux on Z which is big-endian, I do not know if this happen on other BE systems.