### PR TITLE
Make ByteArray trait public (sealed)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,8 @@ use swisstable_group_query::REFERENCE_GROUP_SIZE;
 pub use crate::fxhash::FxHashFn;
 pub use crate::unhash::UnHashFn;
 
-use crate::raw_table::{ByteArray, RawIter, RawTable, RawTableMut};
+pub use crate::raw_table::ByteArray;
+use crate::raw_table::{RawIter, RawTable, RawTableMut};
 
 /// This trait provides a complete "configuration" for a hash table, i.e. it
 /// defines the key and value types, how these are encoded and what hash
@@ -809,6 +810,7 @@ mod tests {
             }
         }
 
+        impl<const L: usize> crate::raw_table::sealed::Sealed for Bytes<L> {}
         impl<const L: usize> ByteArray for Bytes<L> {
             #[inline(always)]
             fn zeroed() -> Self {

--- a/src/raw_table.rs
+++ b/src/raw_table.rs
@@ -443,9 +443,18 @@ where
     }
 }
 
-/// A trait that lets us abstract over different lengths of fixed size byte
-/// arrays. Don't implement it for anything other than fixed size byte arrays!
-pub trait ByteArray: Sized + Copy + Eq + Clone + PartialEq + fmt::Debug + 'static {
+pub(crate) mod sealed {
+    pub trait Sealed {}
+    impl<const LEN: usize> Sealed for [u8; LEN] {}
+}
+
+/// A trait that abstracts over different lengths of fixed size byte arrays.
+///
+/// This trait is sealed — it cannot be implemented outside of this crate.
+/// It is implemented for all `[u8; N]` arrays via const generics.
+pub trait ByteArray:
+    sealed::Sealed + Sized + Copy + Eq + Clone + PartialEq + fmt::Debug + 'static
+{
     fn zeroed() -> Self;
     fn as_slice(&self) -> &[u8];
     fn equals(&self, other: &Self) -> bool;


### PR DESCRIPTION
ByteArray is currently private. It's defined as pub in raw_table.rs but the module itself is not re-exported, so downstream crates can't name it. This is sometimes an issue when writing generic code.

This PR re-exports ByteArray from the crate root and seals it with a private supertrait (Sealed), so downstream code can use ByteArray as a trait bound, but it still can't have implementations other than the ones in this crate.

Code example:
```rust
// ByteArray is private:
//
// We can't name ByteArray in bounds, so encoding traits must use
// const generics for the byte array size:

trait Encode<const S: usize> {
    fn encode(&self) -> [u8; S];
    fn decode(bytes: &[u8; S]) -> Self;
}

// Config needs both key and value byte sizes as extra type params:
struct MyCfg<K, V, const KS: usize, const VS: usize>(PhantomData<(K, V)>);

impl<K: Encode<KS>, V: Encode<VS>, const KS: usize, const VS: usize>
    Config for MyCfg<K, V, KS, VS> { /* ... */ }

// But KS and VS can't be inferred — the compiler can't compute them
// from K and V. So every concrete use must spell them out:
type Cfg1 = MyCfg<MyKey, u16, 4, 2>;
type Cfg2 = MyCfg<MyKey, u32, 4, 4>;
// ... or use macros to generate all combinations.


// ByteArray is public:
//
// Encoding traits use an associated type bounded by ByteArray:

trait Encode {
    type Encoded: odht::ByteArray;
    fn encode(&self) -> Self::Encoded;
    fn decode(bytes: &Self::Encoded) -> Self;
}

// Config is fully generic — no extra type params:
struct MyCfg<K, V>(PhantomData<(K, V)>);

impl<K: Encode, V: Encode> Config for MyCfg<K, V> {
    type EncodedKey = K::Encoded;    // compiler proves ByteArray
    type EncodedValue = V::Encoded;
    // ...
}

// Just works:
type Cfg1 = MyCfg<MyKey, u16>;
type Cfg2 = MyCfg<MyKey, u32>;
```